### PR TITLE
Fix docker build error

### DIFF
--- a/adaptor_server/requirements.txt
+++ b/adaptor_server/requirements.txt
@@ -2,4 +2,3 @@ connexion == 2.6.0
 python_dateutil == 2.6.0
 setuptools >= 21.0.0
 swagger-ui-bundle==0.0.6
-pprint==0.1


### PR DESCRIPTION
An issue with `pprint==0.1` being included in the requirements
list was preventing`docker build` from executing successfully.

This pull request fixes this by removing it from 
`requirements.txt`, as it is part of the standard library.

Signed-off-by: Elis Lulja <elulja@cisco.com>